### PR TITLE
fix: use commit SHAs for TruffleHog base/head

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -40,8 +40,8 @@ jobs:
         uses: trufflesecurity/trufflehog@main
         with:
           path: ./
-          base: ${{ github.event.repository.default_branch }}
-          head: HEAD
+          base: ${{ github.event_name == 'pull_request' && github.event.pull_request.base.sha || github.event.before }}
+          head: ${{ github.event_name == 'pull_request' && github.event.pull_request.head.sha || github.sha }}
           extra_args: --only-verified
 
   # ══════════════════════════════════════════════════════════════════════════


### PR DESCRIPTION
When pushing to the default branch, using the branch name as base and HEAD resolves to the same commit — TruffleHog errors with "BASE and HEAD commits are the same".

Fix: use PR base/head SHAs for pull_request events, and github.event.before/github.sha for push events.