### PR TITLE
fix: pin distroless base image to :nonroot tag

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -19,7 +19,7 @@ RUN npm test
 # =============================================================================
 # Stage 3: Production image — gcr.io/distroless (no shell, minimal attack surface)
 # =============================================================================
-FROM gcr.io/distroless/nodejs20-debian12 AS production
+FROM gcr.io/distroless/nodejs20-debian12:nonroot AS production
 
 WORKDIR /app
 


### PR DESCRIPTION
Checkov CKV_DOCKER_7 requires an explicit image tag. Using :nonroot is semantically correct since the container already runs as UID 65532.